### PR TITLE
Fix syntax error causing startUploading to not be defined.

### DIFF
--- a/Dremel3D-CuraPrintr/Dremel3DOutputDevice.py
+++ b/Dremel3D-CuraPrintr/Dremel3DOutputDevice.py
@@ -123,7 +123,7 @@ class Dremel3DOutputDevice(OutputDevice):
 
         ## TODO: just upload directly here
         self._startPrint = True
-        startUploading()
+        self.startUploading()
 
     def onFilenameChanged(self):
         fileName = self._dialog.findChild(QObject, "nameField").property("text").strip()


### PR DESCRIPTION
This should fix the syntax error that was caused by release 1.0.2 that forgot a`self.`